### PR TITLE
ports/unix: add LWIP_UNIX_ANDROID to LWIP_ERRNO_STDINCLUDE=1 branch

### DIFF
--- a/src/ports/unix/include/cc.h
+++ b/src/ports/unix/include/cc.h
@@ -54,7 +54,7 @@
 
 #define LWIP_ERRNO_INCLUDE <errno.h>
 
-#if defined(LWIP_UNIX_LINUX) || defined(LWIP_UNIX_HURD) || defined(LWIP_UNIX_KFREEBSD)
+#if defined(LWIP_UNIX_LINUX) || defined(LWIP_UNIX_HURD) || defined(LWIP_UNIX_KFREEBSD) || defined(LWIP_UNIX_ANDROID)
 #define LWIP_ERRNO_STDINCLUDE	1
 #endif
 


### PR DESCRIPTION
On Android, Bionic libc defines 'errno' as a macro that expands to a function call ('(*__errno())'). Combined with LWIP's 'LWIP_ERRNO_INCLUDE <errno.h>' define, the preprocessor substitutes the 'errno' token inside '<errno.h>' before the '#include' directive is processed, producing invalid '<(*__errno()).h>' and fatal 'file not found' error.

Linux, HURD and KFreeBSD already set LWIP_ERRNO_STDINCLUDE=1 so that errno.h is included directly via '#include <errno.h>' (without going through LWIP_ERRNO_INCLUDE macro indirection). Android's libc has the same issue and benefits from the same fix.

Repro before patch (NDK r27+/r30-beta1, API 28+):
    third-part/lwip/src/include/lwip/errno.h:188:10: fatal error:
    '(*__errno()).h' file not found
    #include LWIP_ERRNO_INCLUDE
             ^~~~~~~~~~~~~~~~~~
    /src/ports/unix/include/cc.h:55:28: note: expanded from macro
    'LWIP_ERRNO_INCLUDE'
    #define LWIP_ERRNO_INCLUDE <errno.h>

After patch: compiles cleanly on Android for all three ABI (arm64-v8a, armeabi-v7a, x86_64). Discovered building heiher/hev-socks5-tunnel on NDK r30.